### PR TITLE
switch the solo12 to stl files for display in gepetto viewer.

### DIFF
--- a/xacro/solo12.urdf.xacro
+++ b/xacro/solo12.urdf.xacro
@@ -8,7 +8,7 @@
   <xacro:property name="color_name" value="grey" />
   <xacro:property name="color" value="0.8 0.8 0.8" />
   <xacro:property name="opacity" value="1.0" />
-  <xacro:property name="mesh_ext" value="obj" />
+  <xacro:property name="mesh_ext" value="stl" />
 
   <!-- This file is based on: https://atlas.is.localnet/confluence/display/AMDW/Quadruped+URDF+Files -->
   <link name="base_link">


### PR DESCRIPTION
## Why?

With a recent release of gepetto viewer the .obj does not work properly so I fall both model back to stl.

## To do:

Create a xacro file for both version stl/obj and maybe a symbolic link or define both version in the python config file.