### PR TITLE
Solo12 wrapper: Make slider reading work when using p.DIRECT instead of p.GUI

### DIFF
--- a/src/robot_properties_solo/solo12wrapper.py
+++ b/src/robot_properties_solo/solo12wrapper.py
@@ -113,11 +113,15 @@ class Solo12Robot(PinBulletWrapper):
         self.pin_robot.centroidalMomentum(q, dq)
 
     def get_slider_position(self, letter):
-        if letter == "a":
-            return pybullet.readUserDebugParameter(self.slider_a)
-        if letter == "b":
-            return pybullet.readUserDebugParameter(self.slider_b)
-        if letter == "c":
-            return pybullet.readUserDebugParameter(self.slider_c)
-        if letter == "d":
-            return pybullet.readUserDebugParameter(self.slider_d)
+        try:
+            if letter == "a":
+                return pybullet.readUserDebugParameter(self.slider_a)
+            if letter == "b":
+                return pybullet.readUserDebugParameter(self.slider_b)
+            if letter == "c":
+                return pybullet.readUserDebugParameter(self.slider_c)
+            if letter == "d":
+                return pybullet.readUserDebugParameter(self.slider_d)
+        except:
+            # In case of not using a GUI.
+            return 0.


### PR DESCRIPTION
Turns out when running the bullet simulator without GUI, reading the slider values from the GUI yields an exception. As a workaround, I am listening for an exception and if one occurred, I just return a zero slider value.