### PR TITLE
Solo12: Add sent/lost messages to sensor data

### DIFF
--- a/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12.yaml
+++ b/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12.yaml
@@ -45,6 +45,14 @@ device:
       size: 6
     motor_board_errors:
       size: 6
+    num_sent_command_packets:
+      size: 1
+    num_lost_command_packets:
+      size: 1
+    num_sent_sensor_packets:
+      size: 1
+    num_lost_sensor_packets:
+      size: 1
   controls:
     ctrl_joint_torques:
       size: 12

--- a/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_mpi_is.yaml
+++ b/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_mpi_is.yaml
@@ -42,6 +42,14 @@ device:
       size: 6
     motor_board_errors:
       size: 6
+    num_sent_command_packets:
+      size: 1
+    num_lost_command_packets:
+      size: 1
+    num_sent_sensor_packets:
+      size: 1
+    num_lost_sensor_packets:
+      size: 1
   controls:
     ctrl_joint_torques:
       size: 12

--- a/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_nyu.yaml
+++ b/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_nyu.yaml
@@ -42,6 +42,14 @@ device:
       size: 6
     motor_board_errors:
       size: 6
+    num_sent_command_packets:
+      size: 1
+    num_lost_command_packets:
+      size: 1
+    num_sent_sensor_packets:
+      size: 1
+    num_lost_sensor_packets:
+      size: 1
   controls:
     ctrl_joint_torques:
       size: 12

--- a/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_wireless_mpi_is.yaml
+++ b/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_wireless_mpi_is.yaml
@@ -42,6 +42,14 @@ device:
       size: 6
     motor_board_errors:
       size: 6
+    num_sent_command_packets:
+      size: 1
+    num_lost_command_packets:
+      size: 1
+    num_sent_sensor_packets:
+      size: 1
+    num_lost_sensor_packets:
+      size: 1
   controls:
     ctrl_joint_torques:
       size: 12


### PR DESCRIPTION
## Description

Add the sent/lost messages info (added in https://github.com/open-dynamic-robot-initiative/solo/pull/112) to the sensor data.


## How I Tested

By printing the values in one of the example scripts.

## Do not merge before

https://github.com/open-dynamic-robot-initiative/solo/pull/112

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
