### PR TITLE
Add power board measurements to Solo12 sensor data

### DIFF
--- a/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12.yaml
+++ b/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12.yaml
@@ -36,6 +36,12 @@ device:
       size: 3
     imu_attitude:
       size: 4
+    powerboard_current:
+      size: 1
+    powerboard_voltage:
+      size: 1
+    powerboard_energy:
+      size: 1
     # robot status
     motor_enabled:
       size: 12

--- a/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_mpi_is.yaml
+++ b/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_mpi_is.yaml
@@ -33,6 +33,12 @@ device:
       size: 3
     imu_attitude:
       size: 4
+    powerboard_current:
+      size: 1
+    powerboard_voltage:
+      size: 1
+    powerboard_energy:
+      size: 1
     # robot status
     motor_enabled:
       size: 12

--- a/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_nyu.yaml
+++ b/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_nyu.yaml
@@ -33,6 +33,12 @@ device:
       size: 3
     imu_attitude:
       size: 4
+    powerboard_current:
+      size: 1
+    powerboard_voltage:
+      size: 1
+    powerboard_energy:
+      size: 1
     # robot status
     motor_enabled:
       size: 12

--- a/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_wireless_mpi_is.yaml
+++ b/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_wireless_mpi_is.yaml
@@ -33,6 +33,12 @@ device:
       size: 3
     imu_attitude:
       size: 4
+    powerboard_current:
+      size: 1
+    powerboard_voltage:
+      size: 1
+    powerboard_energy:
+      size: 1
     # robot status
     motor_enabled:
       size: 12


### PR DESCRIPTION
## Description

Add the powerboard-values added in https://github.com/open-dynamic-robot-initiative/solo/pull/113 to the Solo12 config files.



## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [ ] https://github.com/open-dynamic-robot-initiative/solo/pull/113

