### PR TITLE
Add method to reset Solo12 to initial state

### DIFF
--- a/src/robot_properties_solo/solo12wrapper.py
+++ b/src/robot_properties_solo/solo12wrapper.py
@@ -7,8 +7,9 @@ Copyright (C) 2018-2019, New York University , Max Planck Gesellschaft
 Copyright note valid unless otherwise stated in individual files.
 All rights reserved.
 """
-
+import numpy as np
 import pybullet
+
 from bullet_utils.wrapper import PinBulletWrapper
 from robot_properties_solo.config import Solo12Config
 
@@ -122,6 +123,12 @@ class Solo12Robot(PinBulletWrapper):
                 return pybullet.readUserDebugParameter(self.slider_c)
             if letter == "d":
                 return pybullet.readUserDebugParameter(self.slider_d)
-        except:
+        except Exception:
             # In case of not using a GUI.
             return 0.
+
+    def reset_to_initial_state(self) -> None:
+        """Reset robot state to the initial configuration (based on Solo12Config)."""
+        q0 = np.matrix(Solo12Config.initial_configuration).T
+        dq0 = np.matrix(Solo12Config.initial_velocity).T
+        self.reset_state(q0, dq0)


### PR DESCRIPTION
## Description

The new `reset_to_initial_state` method gets initial positions and velocities from Solo12Config and uses it to reset the simulation.

This simplifies the setup, especially when used from within C++ code (needed for simulation driver in https://github.com/open-dynamic-robot-initiative/robot_interfaces_solo/pull/3).


## How I Tested

By using it in https://github.com/open-dynamic-robot-initiative/robot_interfaces_solo/pull/3.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
