### PR TITLE
Set serial_port to "auto"

### DIFF
--- a/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12.yaml
+++ b/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12.yaml
@@ -88,4 +88,4 @@ hardware_communication:
   cpu_id: 0
 
   network_id: "ens4"
-  serial_port: "/dev/this_doesnt_matter_see_serial_reader.cpp"
+  serial_port: "auto"

--- a/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_mpi_is.yaml
+++ b/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_mpi_is.yaml
@@ -77,7 +77,7 @@ hardware_communication:
                           0.210, 0.733, 0.156,
                           0.014, 0.212, 0.178]
   network_id: "ens4"
-  serial_port: "/dev/this_doesnt_matter_see_serial_reader.cpp"
+  serial_port: "auto"
 
   ros_node_name: "solo12"
   shared_memory_name: "DGM_ShM"

--- a/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_nyu.yaml
+++ b/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_nyu.yaml
@@ -79,7 +79,7 @@ hardware_communication:
        -0.046, 0.257, 0.438
     ]
   network_id: "enp5s0f1"
-  serial_port: "/dev/this_doesnt_matter_see_serial_reader.cpp"
+  serial_port: "auto"
 
   ros_node_name: "solo12"
   shared_memory_name: "DGM_ShM"

--- a/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_wireless_mpi_is.yaml
+++ b/src/robot_properties_solo/resources/dynamic_graph_manager/dgm_parameters_solo12_wireless_mpi_is.yaml
@@ -77,7 +77,7 @@ hardware_communication:
                           0.543, 0.058, 0.219,
                           -0.145, 0.357, 0.655, ]
   network_id: "enp0s31f6"
-  serial_port: "/dev/this_doesnt_matter_see_serial_reader.cpp"
+  serial_port: "auto"
 
   ros_node_name: "solo12"
   shared_memory_name: "DGM_ShM"


### PR DESCRIPTION
## Description

With an upcoming change in slider_box (https://github.com/open-dynamic-robot-initiative/slider_box/pull/2) the behaviour changes such that auto-detection is only done if the port is explicitly set to "auto".  Thus changing it here to maintain the current behaviour.

This change is backwards compatible with older versions of slider_box as there auto-detection is done in any case.



## How I Tested

Not tested.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
